### PR TITLE
Fixed System.NullReferenceException on SLDocument creation on Linux

### DIFF
--- a/misc/SLSimpleTheme.cs
+++ b/misc/SLSimpleTheme.cs
@@ -461,7 +461,7 @@ internal class SLSimpleTheme
         get { return lThemeRowHeightInEMU; }
     }
 
-    internal List<double> listColumnStepSize;
+    internal List<double> listColumnStepSize = new();
 
     internal SLSimpleTheme(WorkbookPart wbp, SLThemeTypeValues themetype, bool ThrowExceptionsIfAny)
     {


### PR DESCRIPTION
Fixed a System.NullReferenceException on SLDocument when it tries to create a new file on Linux.